### PR TITLE
Added an option to turn off welcome broadcasts, fixed the setup UI

### DIFF
--- a/bot/config_handler.py
+++ b/bot/config_handler.py
@@ -53,6 +53,7 @@ class ConfigHandler:
             {'section': 'bot', 'key': 'default_channel', 'type': 'text', 'prompt': self._("Default Channel"), 'help_text': self._("The full path of the channel the bot should join after login (e.g., '/chatting'). The default is the root channel (/)."), 'default': "/"},
             {'section': 'bot', 'key': 'channel_password', 'type': 'text', 'prompt': self._("Channel Password"), 'help_text': self._("The password for the default channel, if required.")},
             {'section': 'bot', 'key': 'status_message', 'type': 'text', 'prompt': self._("Status Message"), 'help_text': self._("An optional status message for the bot.")},
+            {'section': 'bot', 'key': 'welcome_broadcast', 'type': 'bool', 'prompt': self._("Send Welcome Broadcast?"), 'help_text': self._("Send a public welcome message when a user logs in."), 'default': True},
             {'section': 'bot', 'key': 'random_message_interval', 'type': 'int', 'prompt': self._("Random Message Interval (minutes)"), 'help_text': self._("Interval in minutes for sending random broadcast messages from messages.txt. Set to 0 to disable."), 'default': 0},
 
             {'type': 'header', 'text': self._("Audio and Playback Settings")},
@@ -431,6 +432,7 @@ class ConfigHandler:
                 "default_channel": bot_section.get("default_channel", "/"),
                 "channel_password": bot_section.get("channel_password", ""),
                 "status_message": bot_section.get("status_message", ""),
+                "welcome_broadcast": bot_section.getboolean("welcome_broadcast", True),
                 "vpn_detection": bot_section.getboolean("vpn_detection", True),
                 "prevent_noname": bot_section.getboolean("prevent_noname", True),
                 "noname_note": bot_section.get("noname_note", ""),
@@ -540,6 +542,7 @@ class ConfigHandler:
                 "default_channel": str(bot_config['default_channel']),
                 "channel_password": str(bot_config['channel_password']),
                 "status_message": str(bot_config["status_message"]),
+                "welcome_broadcast": str(bot_config.get('welcome_broadcast', True)),
                 "vpn_detection": str(bot_config['vpn_detection']),
                 "prevent_noname": str(bot_config['prevent_noname']),
                 "noname_note": str(bot_config['noname_note']),

--- a/bot/modules/admin.py
+++ b/bot/modules/admin.py
@@ -1,5 +1,5 @@
 from TeamTalk5 import BanType, BannedUser, UserAccount, UserType, TextMsgType, TextMessage, ttstr
-from bot.utils import BotUtils as utils
+from bot.utils import BotUtils as utils, ShutdownSignal, RestartSignal
 import TeamTalk5 as teamtalk
 import time
 from threading import Thread
@@ -34,6 +34,22 @@ class AdminCog:
         command_handler.register_command('cs', self.handle_change_status, admin_only=True, help_text=self._("Changes the bot's status message. Usage: /cs <new_status>"))
         command_handler.register_command('cg', self.handle_change_gender, admin_only=True, help_text=self._("Changes the bot's gender. Usage: /cg <m|f|n>. send /cg without arguments for more details."))
         command_handler.register_command('new', self.handle_new_account_command, admin_only=True, help_text=self._("Creates a new user account. Usage: /new <user> <pass> [rights]. the rights is a list of user rights separated by spaces for each number."))
+        command_handler.register_command('shutdown', self.handle_shutdown_command, admin_only=True, help_text=self._("Shuts down the bot."))
+        command_handler.register_command('sd', self.handle_shutdown_command, admin_only=True, help_text=self._("Alias for /shutdown."))
+        command_handler.register_command('restart', self.handle_restart_command, admin_only=True, help_text=self._("Restarts the bot."))
+        command_handler.register_command('rs', self.handle_restart_command, admin_only=True, help_text=self._("Alias for /restart."))
+
+    def handle_shutdown_command(self, textmessage, *args):
+        """Handles the command to shut down the bot."""
+        self.bot.privateMessage(textmessage.nFromUserID, self._("Shutting down..."))
+        print("\nShutdown requested by admin command.")
+        raise ShutdownSignal
+
+    def handle_restart_command(self, textmessage, *args):
+        """Handles the command to restart the bot."""
+        self.bot.privateMessage(textmessage.nFromUserID, self._("Restarting..."))
+        print("\nRestart requested by admin command.")
+        raise RestartSignal
 
     def handle_user_login_checks(self, user):
         """Handles all administrative checks when a user logs in."""

--- a/bot/modules/general.py
+++ b/bot/modules/general.py
@@ -16,6 +16,7 @@ class GeneralCog:
         command_handler.register_command('weather', self.handle_weather_command, help_text=self._("Gets the current weather info for your location or a specified user. Usage: /weather <nickname (Optional)>"))
         command_handler.register_command('search', self.handle_search_command, help_text=self._("Searches Wikipedia for a summary. Usage: /search <query>"))
         command_handler.register_command('h', self.handle_help_command, help_text=self._("Shows this help message."))
+        command_handler.register_command('help', self.handle_help_command, help_text=self._("Shows this help message."))
         command_handler.register_command('myinfo', self.handle_myinfo_command, help_text=self._("Shows your user account information."))
 
     def handle_weather_command(self, textmessage, *args):
@@ -118,7 +119,7 @@ class GeneralCog:
         
         self.bot.privateMessage(user_id, self._("--- Available Commands ---"))
         # Sort commands alphabetically for readability
-        commands = self.bot.command_handler.commands.items()
+        commands = sorted(self.bot.command_handler.commands.items())
         for name, command in commands:
             # If the command is admin-only and the user is not an admin, skip it
             if command.admin_only and not is_admin:

--- a/bot/tt_utilities.py
+++ b/bot/tt_utilities.py
@@ -13,6 +13,7 @@ from bot.user_manager import UserManager
 import gettext
 import logging
 import time
+import traceback
 from datetime import datetime
 import os, sys, re, configparser, argparse
 import random
@@ -96,16 +97,35 @@ class TTUtilities(TeamTalk):
 
     def shutdown(self):
         """Cleanly shuts down all resources used by the bot instance."""
+        print("Shutdown sequence started.")
         try:
-            self.player.terminate()            
-            self.disconnect()            
+            print("Terminating media player...")
+            self.player.terminate()
+            print("Media player terminated.")
+
+            print("Disconnecting from TeamTalk server...")
+            self.disconnect()
+            print("Disconnected from server.")
+
+            print("Closing TeamTalk instance...")
             self.closeTeamTalk()
-            self.io_pool.shutdown(wait=False)
-            self.quick_task_pool.shutdown(wait=False)
+            print("TeamTalk instance closed.")
+
+            if self.io_pool:
+                print("Shutting down IO thread pool...")
+                self.io_pool.shutdown(wait=False)
+                print("IO thread pool shutdown initiated.")
+            
+            if self.quick_task_pool:
+                print("Shutting down quick task thread pool...")
+                self.quick_task_pool.shutdown(wait=False)
+                print("Quick task thread pool shutdown initiated.")
+
             print("Shutdown complete.")
         except Exception as e:
             logging.error(f"Error during shutdown: {e}")
             print(f"An error occurred during shutdown: {e}")
+            traceback.print_exc()
 
     def _register_cogs(self):
         """Initializes and registers all command cogs."""

--- a/bot/user_manager.py
+++ b/bot/user_manager.py
@@ -54,23 +54,24 @@ class UserManager:
             del self.user_messages[username]
         
         # 3. Handle Welcome Message and Location-based Actions
-        country, city = self.get_user_location(user.nUserID)
-        if country and city:
-            welcome_messages = [
-                self._("Welcome, {nickname} from {country}!").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Ahoy there, {nickname} from {country}! Welcome aboard!").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Greetings, {nickname} of {country}! We're glad to have you here.").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Howdy, {nickname}! Welcome from {country}.").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Whoa! {nickname} just arrived from {country}! Let's party!").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Look who's here! {nickname} from {country} just logged in!").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Good vibes only for {nickname} from {country}! Welcome, my friend!").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Surprise, surprise! It's {nickname} from {country}! Glad to have you!").format(nickname=ttstr(user.szNickname), country=country),
-                self._("Let the fun begin! Welcome, {nickname} from the land of {country}!").format(nickname=ttstr(user.szNickname), country=country)
-            ]
+        if self.bot.bot_config.get("welcome_broadcast", True):
+            country, city = self.get_user_location(user.nUserID)
+            if country and city:
+                welcome_messages = [
+                    self._("Welcome, {nickname} from {country}!").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Ahoy there, {nickname} from {country}! Welcome aboard!").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Greetings, {nickname} of {country}! We're glad to have you here.").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Howdy, {nickname}! Welcome from {country}.").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Whoa! {nickname} just arrived from {country}! Let's party!").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Look who's here! {nickname} from {country} just logged in!").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Good vibes only for {nickname} from {country}! Welcome, my friend!").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Surprise, surprise! It's {nickname} from {country}! Glad to have you!").format(nickname=ttstr(user.szNickname), country=country),
+                    self._("Let the fun begin! Welcome, {nickname} from the land of {country}!").format(nickname=ttstr(user.szNickname), country=country)
+                ]
 
-            self.bot.send_broadcast_message(random.choice(welcome_messages))
-        else:
-            self.bot.send_broadcast_message(self._("{nickname} has joined the server").format(nickname=nickname))
+                self.bot.send_broadcast_message(random.choice(welcome_messages))
+            else:
+                self.bot.send_broadcast_message(self._("{nickname} has joined the server").format(nickname=nickname))
 
     def on_user_parted(self, user):
         """Cleans up all data associated with a user when they leave or log out."""

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -10,6 +10,15 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 
 
+class ShutdownSignal(Exception):
+    """Custom exception to signal a clean shutdown from a command."""
+    pass
+
+class RestartSignal(Exception):
+    """Custom exception to signal a clean restart from a command."""
+    pass
+
+
 class BotUtils:
     """
     A class for standalone utility functions used by the bot.


### PR DESCRIPTION
* A new config option, welcome_broadcast, decides whether welcome broadcasts are sent when someone joins a server. Set to False to turn them off. This option is also present in the initial setup UI. When you next run the bot after updating, you will be prompted to have the bot update config.ini with this new option. Once the config file is updated, run the bot again.
* Fixed the setup UI so that username and password actually get added to config.ini. Also, the TeamTalk server port is not the same as the SSH port, OK?
* The /help command actually works now instead of doing nothing.
* New /shutdown (/sd) and /restart (/rs) commands have been added to shut down and restart the bot.